### PR TITLE
Exporter fix, prettifyEffects, search-defs

### DIFF
--- a/resources/magic-egg-allinone-exporter.mse-export-template/export-template
+++ b/resources/magic-egg-allinone-exporter.mse-export-template/export-template
@@ -15,12 +15,13 @@ file type: *.txt|*.txt|*.*|*.*
 
 #JSON implementation by Fungustober
 
-option field:
-	type: choice
-	name: export images
-	choice: yes
-	choice: no
-	description: Export images
+#Aanginer: removed this because it practically should never be turned off, if you think its needed, feel free to uncomment it
+#option field:
+#	type: choice
+#	name: export images
+#	choice: yes
+#	choice: no
+#	description: Export images
 
 option field:
 	type: choice
@@ -246,6 +247,10 @@ script:
 		else card.shape
 	}
 
+	## Aanginer: In case of a mutate box, check for special_text
+	full_text := { if (card.special_text == "") then card.rule_text else card.special_text }
+	full_text2 := { if (card.special_text2 == "") then card.rule_text2 else card.special_text2 }
+
 	is_double_card := match@(match:"double|adventure|aftermath|spli")
 	q := "\""
 	write_card := {
@@ -257,14 +262,15 @@ script:
 			"{q}number{q}: {sanitize(card_number())}",
 			"{q}color_identity{q}: {q}{get_color_identity()}{q}",
 			"{q}cost{q}: {q}{mana_cost_replacement_css(card.casting_cost)}{q}",
-			"{q}rules_text{q}: {q}{format_textbox(card.rule_text)}{q}",
+			"{q}rules_text{q}: {q}{format_textbox(full_text())}{q}",
 			"{q}flavor_text{q}: {q}{format_textbox(card.flavor_text)}{q}",
 			"{q}pt{q}: {q}{sanitize(card.pt)}{q}",
 			"{q}special_text{q}: {q}{format_textbox(card.special_text)}{q}",
 			"{q}shape{q}: {q}{get_shape()}{q}",
 			"{q}set{q}: {q}{adj_setcode()}{q}",
 			"{q}loyalty{q}: {q}{sanitize(card.loyalty)}{q}",
-			"{q}artist{q}: {q}{sanitize(card.illustrator)}{q}"
+			"{q}artist{q}: {q}{sanitize(card.illustrator)}{q}",
+			"{q}alias{q}: {q}{sanitize(card.alias)}{q}"
 		]
 		if is_double_card(card.shape) then strings := strings + [
 			"{q}card_name2{q}: {q}{card_name_2()}{q}",
@@ -274,9 +280,10 @@ script:
 			"{q}rules_text2{q}: {q}{format_textbox(card.rule_text_2)}{q}",
 			"{q}flavor_text2{q}: {q}{format_textbox(card.flavor_text_2)}{q}",
 			"{q}pt2{q}: {q}{sanitize(sanitize(card.pt_2))}{q}",
-			"{q}special_text2{q}: {q}{format_textbox(card.special_text_2)}{q}",
+			"{q}special_text2{q}: {q}{format_textbox(full_text2())}{q}",
 			"{q}loyalty2{q}: {q}{sanitize(card.loyalty_2)}{q}",
-			"{q}artist2{q}: {q}{sanitize(card.illustrator_2)}{q}"
+			"{q}artist2{q}: {q}{sanitize(card.illustrator_2)}{q}",
+			"{q}alias2{q}: {q}{sanitize(card.alias2)}{q}"
 		]
 		strings := strings + [
 			"{q}notes{q}: {q}{sanitize(card.notes)}{q}"
@@ -308,10 +315,11 @@ script:
 	write_text_file(file: adj_setcode() + ".json", "\{" + join(main_keys) + "}")
 
 	write_image_file({symbol_variation(symbol: set.symbol, variation: options.symbol_rarity)}(), file: "icon.png", width: 512, height: 512)
-	write_image_file({symbol_variation(symbol: set.symbol, variation: options.symbol_rarity)}(), file: "logo.png", width: 320, height: 320)
+	#write_image_file({symbol_variation(symbol: set.symbol, variation: options.symbol_rarity)}(), file: "logo.png", width: 320, height: 320)
 
 	if options.export_description == "yes"
 		then write_text_file(file: "splash.md", set.description)
 
-	write_images := if options.export_images == "yes" then write_all_images() else ""
+	# Aanginer: this line is here because I don't want to touch this part of the mse exporter code
+	write_images := write_all_images
 	"This file doesn't contain anything. Exported files can be found in the name-files folder with the same name you saved as."

--- a/resources/magic-egg-allinone-exporter.mse-export-template/export-template
+++ b/resources/magic-egg-allinone-exporter.mse-export-template/export-template
@@ -15,7 +15,7 @@ file type: *.txt|*.txt|*.*|*.*
 
 #JSON implementation by Fungustober
 
-#Aanginer: removed this because it practically should never be turned off, if you think its needed, feel free to uncomment it
+#Aanginer: removed this because it practically should never be turned off, if you think its needed, feel free to uncomment it and re-add the condition at the end of the code
 #option field:
 #	type: choice
 #	name: export images
@@ -247,9 +247,9 @@ script:
 		else card.shape
 	}
 
-	## Aanginer: In case of a mutate box, check for special_text
-	full_text := { if (card.special_text == "") then card.rule_text else card.special_text }
-	full_text2 := { if (card.special_text2 == "") then card.rule_text2 else card.special_text2 }
+	## Aanginer: In case of a mutate box or something similar, check for special_text
+	full_text := { if card.special_text == "" then card.rule_text else card.special_text }
+	full_text2 := { if card.special_text2 == "" then card.rule_text2 else card.special_text2 }
 
 	is_double_card := match@(match:"double|adventure|aftermath|spli")
 	q := "\""

--- a/resources/magic-egg-allinone-exporter.mse-export-template/export-template
+++ b/resources/magic-egg-allinone-exporter.mse-export-template/export-template
@@ -15,13 +15,12 @@ file type: *.txt|*.txt|*.*|*.*
 
 #JSON implementation by Fungustober
 
-#Aanginer: removed this because it practically should never be turned off, if you think its needed, feel free to uncomment it and re-add the condition at the end of the code
-#option field:
-#	type: choice
-#	name: export images
-#	choice: yes
-#	choice: no
-#	description: Export images
+option field:
+	type: choice
+	name: export images
+	choice: yes
+	choice: no
+	description: Export images
 
 option field:
 	type: choice
@@ -64,6 +63,13 @@ option field:
 	choice: no
 	choice: yes
 	description: Export set description as splash page
+
+option field:
+	type: choice
+	name: unpreviewed card image
+	choice: card back
+	choice: empty
+	description: What should display on the preview gallery for unpreviewed cards
 
 script:
 	fix_tm := replace@(match:"™", replace:"TM")
@@ -236,6 +242,10 @@ script:
 		else base_ci
 	}
 
+	##Grab special_text if it's not empty, otherwise grab rule_text
+	full_text := { if card.special_text != "" then card.special_text else card.rule_text }
+	full_text2 := { if card.special_text_2 != "" then card.special_text_2 else card.rule_text_2 }
+
 	##Shape function to deal with all the non-standard shapes
 	get_shape := {
 		if card.shape == "emblem"
@@ -246,10 +256,6 @@ script:
 			then "token"
 		else card.shape
 	}
-
-	## Aanginer: In case of a mutate box or something similar, check for special_text
-	full_text := { if card.special_text == "" then card.rule_text else card.special_text }
-	full_text2 := { if card.special_text2 == "" then card.rule_text2 else card.special_text2 }
 
 	is_double_card := match@(match:"double|adventure|aftermath|spli")
 	q := "\""
@@ -277,10 +283,10 @@ script:
 			"{q}color2{q}: {q}{card_color_2()}{q}",
 			"{q}type2{q}: {q}{sanitize(card.type_2)}{q}",
 			"{q}cost2{q}: {q}{mana_cost_replacement_css(card.casting_cost_2)}{q}",
-			"{q}rules_text2{q}: {q}{format_textbox(card.rule_text_2)}{q}",
+			"{q}rules_text2{q}: {q}{format_textbox(full_text2())}{q}",
 			"{q}flavor_text2{q}: {q}{format_textbox(card.flavor_text_2)}{q}",
 			"{q}pt2{q}: {q}{sanitize(sanitize(card.pt_2))}{q}",
-			"{q}special_text2{q}: {q}{format_textbox(full_text2())}{q}",
+			"{q}special_text2{q}: {q}{format_textbox(card.special_text_2)}{q}",
 			"{q}loyalty2{q}: {q}{sanitize(card.loyalty_2)}{q}",
 			"{q}artist2{q}: {q}{sanitize(card.illustrator_2)}{q}",
 			"{q}alias2{q}: {q}{sanitize(card.alias2)}{q}"
@@ -310,16 +316,16 @@ script:
 		"{q}trimmed{q}: {q}n{q}",
 		"{q}image_type{q}: {q}{options.image_type}{q}",
 		"{q}draft_structure{q}: {q}{options.draft_structure}{q}",
+		"{q}unpreviewed{q}: {q}{options.unpreviewed_card_image}{q}"
 		"{q}cards{q}: [{write_cards()}]"
 	]
 	write_text_file(file: adj_setcode() + ".json", "\{" + join(main_keys) + "}")
 
 	write_image_file({symbol_variation(symbol: set.symbol, variation: options.symbol_rarity)}(), file: "icon.png", width: 512, height: 512)
-	#write_image_file({symbol_variation(symbol: set.symbol, variation: options.symbol_rarity)}(), file: "logo.png", width: 320, height: 320)
+	write_image_file({symbol_variation(symbol: set.symbol, variation: options.symbol_rarity)}(), file: "logo.png", width: 320, height: 320)
 
 	if options.export_description == "yes"
 		then write_text_file(file: "splash.md", set.description)
 
-	# Aanginer: this line is here because I don't want to touch this part of the mse exporter code
-	write_images := write_all_images
+	write_images := if options.export_images == "yes" then write_all_images() else ""
 	"This file doesn't contain anything. Exported files can be found in the name-files folder with the same name you saved as."

--- a/resources/snippets/img-container-defs.txt
+++ b/resources/snippets/img-container-defs.txt
@@ -22,11 +22,9 @@
 			let card_effects = "";
 			if (card_stats.rules_text != "")
 			{
-				card_effects = card_stats.rules_text.split("\n");
-			}
-			else
-			{
-				card_effects = card_stats.special_text.split("\n");
+				card_effects = card_stats.rules_text + "\n" + (card_stats.flavor_text != "[i][/i]" ? "<hr class=\"ft-divider text-bg\"></div>" + card_stats.flavor_text : ""); // this expression looks cursed but what it does is check if the ft is empty, and if it isn't, insert a divider + the ft
+			} else {
+				card_effects = "";
 			}
 			effect.innerHTML += prettifyEffects(card_effects);
 			text.appendChild(effect);
@@ -73,11 +71,9 @@
 				let card_effects_2 = "";
 				if (card_stats.rules_text2 != "")
 				{
-					card_effects_2 = card_stats.rules_text2.split("\n");
-				}
-				else
-				{
-					card_effects_2 = card_stats.special_text2.split("\n");
+					card_effects_2 = card_stats.rules_text2 + "\n" + (card_stats.flavor_text2 != "[i][/i]" ? "<hr class=\"ft-divider text-bg\"></div>" + card_stats.flavor_text2 : "");
+				} else {
+					card_effects_2 = "";
 				}
 				effect_2.innerHTML += prettifyEffects(card_effects_2);
 				text.appendChild(effect_2);
@@ -200,18 +196,20 @@
             }, seconds * 1000);
         }
 
-		function prettifyEffects(card_effects) {
+		function prettifyEffects(card_effect) {
 			let HTML = "";
+
+			let styled_effect = card_effect.replace(/(\[i\])+(.+?)(\[\/i\])+/gs, function(matched, _1, _2) {
+				return '<i>' + _2 + '</i>'
+			}).replaceAll(/(\[b\])+(.+?)(\[\/b\])+/gs, function(matched, _1, _2) {
+				return '<b>' + _2 + '</b>'
+			});
+
+			let card_effects = styled_effect.split("\n");
 
 			for (let i = 0; i < card_effects.length; i++)
 			{
-				let styled_effect = card_effects[i].replace(/\[i\]([^\]]+)\[\/i\]/g, function(matched, _1) {
-					return '<i>' + _1 + '</i>'
-				}).replace(/\[b\]([^\]]+)\[\/b\]/g, function(matched, _1) {
-					return '<b>' + _1 + '</b>'
-				})
-				
-				HTML += styled_effect;
+				HTML += card_effects[i];
 
 				if (i != card_effects.length - 1)
 				{

--- a/resources/snippets/search-defs.txt
+++ b/resources/snippets/search-defs.txt
@@ -115,7 +115,7 @@ function tokenizeTerms(searchTerms)
 			let card_loyalty = card_stats.loyalty;
 			let card_notes = card_stats.notes;
 			let card_artist = card_stats.artist;
-			let card_alias = card_stats.alias;
+			let card_alias = card_stats.alias ? card_stats.alias : ""; // do this so that we have backwards compatibility
 			let card_color_2 = "";
 			let card_cost_2 = "";
 			let card_power_2 = "";

--- a/resources/snippets/search-defs.txt
+++ b/resources/snippets/search-defs.txt
@@ -115,11 +115,12 @@ function tokenizeTerms(searchTerms)
 			let card_loyalty = card_stats.loyalty;
 			let card_notes = card_stats.notes;
 			let card_artist = card_stats.artist;
+			let card_alias = card_stats.alias;
 			let card_color_2 = "";
 			let card_cost_2 = "";
 			let card_power_2 = "";
 			let card_toughness_2 = "";
-			let card_loyalty_2 = ""
+			let card_loyalty_2 = "";
 
 			let color_map = new Map([
 				["azorius", "wu"],
@@ -603,6 +604,24 @@ function tokenizeTerms(searchTerms)
 					if (modifier == ":" || modifier == "=" || modifier == "!")
 					{
 						return card_artist.includes(check);
+					}
+				}
+				if (term == "godzilla" || term == "alias") {
+					if (modifier == "!" || modifier == "=")
+					{
+						return card_alias == check;
+					}
+					else if (modifier == ":")
+					{
+						return card_alias.includes(check);
+					}
+					else if (modifier == "<")
+					{
+						return card_alias < check;
+					}
+					else if (modifier == ">")
+					{
+						return card_alias > check;
 					}
 				}
 			}

--- a/resources/snippets/search-defs.txt
+++ b/resources/snippets/search-defs.txt
@@ -624,6 +624,10 @@ function tokenizeTerms(searchTerms)
 						return card_alias > check;
 					}
 				}
+				if (modifier == ":" || modifier == "=" || modifier == "!") {
+                    let regex = new RegExp(`!tag<${term}> ${check}\\b`);
+                    return regex.test(card_notes);
+                }
 			}
 
 			return card_name.includes(token);


### PR DESCRIPTION
## Exporter change

Rather than simpy grabbing `card.rule_text` for the rules text property, uses a function called `full_text` which does the following:
`if card.special_text != "" then card.special_text else card.rule_text`; grabs the special_text if its needed, and otherwise uses the normal rules text.
Also exports the card alias (used in godzilla frames) and allows searching by that.

## prettifyEffects change

This change simply shifts where we split by newlines in the code, moving to be after we escape the [i] and [b] tags

## search-defs update

Add search by alias which was added in the exporter change and add the bit of code we talked about in dms.