### PR TITLE
Prevent cards with !tokens notes from being marked as tokens

### DIFF
--- a/resources/magic-egg-allinone-exporter.mse-export-template/export-template
+++ b/resources/magic-egg-allinone-exporter.mse-export-template/export-template
@@ -245,7 +245,7 @@ script:
 		or card.shape == "counter"
 		or card.shape == "rulestip"
 		or card.shape == "checklist"
-		or contains (card.notes, match:"!token")
+		or contains (card.notes, match:"!token") and not contains (card.notes, match:"!tokens")
 			then "token"
 		else card.shape
 	}


### PR DESCRIPTION
This adds a second check to the get_shape function to prevent cards with !tokens notes (reverse token relation) from being given the "token" shape, which causes issues later down the line