### PR TITLE
Ignore card numbers in changelog

### DIFF
--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -176,7 +176,14 @@ for code in set_codes:
 				else:
 					prev_card = previous_data['cards'][prev_card_names.index(card['card_name'])]
 					prev_card_names[prev_card_names.index(card['card_name'])] = ''
-					if card != prev_card:
+
+					# ignore card number, since that often changes for reasons unrelated to the card itself
+					card_copy = card.copy()
+					prev_card_copy = prev_card.copy()
+					card_copy.pop("number", None)
+					prev_card.pop("number", None)
+
+					if card_copy != prev_card_copy:
 						changed = True
 						changed_string += card['card_name'] + '\n'
 						for key in [ 'type', 'cost', 'rules_text', 'pt', 'special_text', 'loyalty' ]:


### PR DESCRIPTION
## Issue

Currently, a card will be added to the changelog if *any* field in the json changes between versions. That includes the card number. However, adding or renaming or deleting or recoloring cards will cause all card numbers to get shuffled around. 

This causes the changelog to get spammed with a bunch of irrelevant card names whenever a card number shuffle happens.

## Change
- Ignore "number" field when checking if a card is equal to its previous version
  - More specifically, we create a copy of each dict and remove the "number" field before doing the dict equality.