### PR TITLE
Fix list_to_list skip logic

### DIFF
--- a/scripts/list_to_list.py
+++ b/scripts/list_to_list.py
@@ -29,8 +29,10 @@ def convertList(setCode):
 		match = re.search(r'!group ([^ \n]+)', cards[i]['notes'])
 		if match and match.group() not in sort_groups:
 			sort_groups.append(match.group())
+		if "token" in cards[i]['shape'] or "Basic" in cards[i]['type']:
+			continue
 		for j in range(i):
-			if cards[i]['card_name'] == cards[j]['card_name'] and "token" not in cards[i]['shape'] and "Basic" not in cards[i]['type']:
+			if cards[i]['card_name'] == cards[j]['card_name'] and "token" not in cards[j]['shape'] and "Basic" not in cards[j]['type']:
 				skipdex.append(cards[j]['number'])
 
 	final_list = []


### PR DESCRIPTION
token copies were causing random cards in sets to be skipped

this code change now skips checking for duplicates between any basic lands or tokens.  if the desired behavior is to remove duplicates within the subset of (all tokens) or (all basic lands), then the logic will have to be altered.  Please review and let me know if this is the desired logic for all sets.

if you want to be able to skip tokens then skipdex would have to also get information about whether the card being added is the same numbering or not.

technically mse is a little weird here, because usually tokens get their own set code, but MSE doesn't have a way to do that unless you create your tokens in a totally separate MSE file.  however even if they got a different set code, this current logic would fail on them.  for robustness, skipdex should probably not just add card number, it should probably also track whether or not the card is part of the main set numbering.