### PR TITLE
Prevent version warning

### DIFF
--- a/resources/magic-egg-allinone-exporter.mse-export-template/export-template
+++ b/resources/magic-egg-allinone-exporter.mse-export-template/export-template
@@ -1,4 +1,4 @@
-mse version: 2.5.8
+mse version: 2.5.7
 short name: Egg's All-in-One
 full name: Egg's All-in-One Exporter
 position hint: 009


### PR DESCRIPTION
Only the full pack is on 2.5.8, so this prevents a warning if used with the normal and basic packs.