### PR TITLE
fix: change reverse_related to reverse-related, implement basic LackeyBot instructions, and make errors more visible

### DIFF
--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -159,7 +159,7 @@ for code in set_codes:
 			print_draft_file.generateFile(code)
 			print('Generated draft file for {0}.'.format(code))
 		except Exception as e:
-			print('Unable to generate draft file for {0}: {1}'.format(code, e))
+			print('! Unable to generate draft file for {0}: {1}'.format(code, e))
 
 	# CE: Trice
 	if not os.path.isfile(os.path.join('custom', 'sets', code + '-files', code + '.xml')):
@@ -167,7 +167,7 @@ for code in set_codes:
 			print_cockatrice_file.generateFile(code)
 			print('Generated Cockatrice file for {0}.'.format(code))
 		except Exception as e:
-			print('Unable to generate Cockatrice file for {0}: {1}'.format(code, e))
+			print('! Unable to generate Cockatrice file for {0}: {1}'.format(code, e))
 
 	#CE: this code is all for version history
 	if 'version' not in raw:


### PR DESCRIPTION
This pull request adds the following changes:

- Corrects the use of reverse_related instead of reverse-related in the Cockatrice XML, causing !related notes to be ineffective.
- Adds the ability to use !addtoken and !replacetoken notes (used for Field Testing) as replacement for !tokens notes
  - A later PR will most likely aim to bridge the gap fully with differentiation between the two notes and addition of the automatic regex parsing of tokens
- Add an exclamation point at the start of error messages to make them more visible in the console output